### PR TITLE
Feature/normalizer docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
+.idea
 composer.lock
 vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ php:
     - hhvm
 
 matrix:
-    allow_failures:
-        - php: 7.0
     include:
         - php: 5.5
           env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.10 (2016-05-22)
+
+New features:
+- [#5](https://github.com/thephpleague/tactician-logger/pull/5): Rather than directly serializing command data into the message, the data is now piped to the log context parameter. This makes it much easier to parse for folks using more complex logging tools.
+
+BC Breaks:
+- Serializers have been replaced by Normalizers. This allows you to pipe the data into the log context in its original form.
+- The Formatter interface has added two new methods for creating the log context (usually from a Normalizer)
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 ## 0.10 (2016-05-22)
 
-New features:
-- [#5](https://github.com/thephpleague/tactician-logger/pull/5): Rather than directly serializing command data into the message, the data is now piped to the log context parameter. This makes it much easier to parse for folks using more complex logging tools.
+This release has a number of BC breaks and refactorings. Specifically:
 
-BC Breaks:
+- The Formatter interface has been completely reworked to allow direct access to the logger (more below).
 - Serializers have been replaced by Normalizers. This allows you to pipe the data into the log context in its original form.
-- The Formatter interface has added two new methods for creating the log context (usually from a Normalizer)
 
+The old interface for a formatter allowed you to return strongs which were then passed to the logger for you. This was the simplest interface but it didn't allow using a number of advanced PSR-3 features like contexts or conditionally changing the log level based on the type of command or exception.
+
+The new Formatter interface passes the logger to you directly so you can log yourself in any way you choose. We've also changed the Serializer to a Normalizer. This might seem tiny but the difference is important: rather than slamming objects down into strings, we now convert them to arrays so they can be passed to the PSR-3 context. This is awesome if you're using more powerful log aggregation/search tools.
+
+We still ship with a couple of simple Formatters built in. These are great examples of how to build your own if you need really advanced logging features and we recommend that instead of adding more features to these.
+
+There's one last change: because the actual logging is now done in Formatters instead of the middleware, you now pass the default log levels to the Formatter rather than the middleware. This is only a convenience for our built-in ones to get you a little further down the road, you don't need to do this for your own formatters.
+
+For more informations:
+- [#5](https://github.com/thephpleague/tactician-logger/pull/5): Rather than directly serializing command data into the message, the data is now piped to the log context parameter. This makes it much easier to parse for folks using more complex logging tools.
+- [#7](https://github.com/thephpleague/tactician-logger/pull/7): Further reworks inspired by a review of #5.

--- a/src/Formatter/ClassNameFormatter.php
+++ b/src/Formatter/ClassNameFormatter.php
@@ -2,6 +2,8 @@
 namespace League\Tactician\Logger\Formatter;
 
 use Exception;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  * Returns log messages only dump the Command & Exception's class names.
@@ -9,45 +11,57 @@ use Exception;
 class ClassNameFormatter implements Formatter
 {
     /**
-     * @param object $command
-     * @return string|null
+     * @var string
      */
-    public function commandReceived($command)
-    {
-        return 'Command received: ' . get_class($command);
-    }
+    private $commandReceivedLevel;
 
     /**
-     * @param object $command
-     * @return string|null
+     * @var string
      */
-    public function commandHandled($command)
-    {
-        return 'Command succeeded: ' . get_class($command);
-    }
+    private $commandSucceededLevel;
 
     /**
-     * @param object $command
-     * @return string|null
+     * @var string
      */
-    public function commandFailed($command)
-    {
-        return 'Command failed: ' . get_class($command);
-    }
+    private $commandFailedLevel;
 
     /**
-     * {@inheritDoc}
+     * @param string $commandReceivedLevel
+     * @param string $commandSucceededLevel
+     * @param string $commandFailedLevel
      */
-    public function commandContext($command)
+    public function __construct($commandReceivedLevel = LogLevel::DEBUG, $commandSucceededLevel = LogLevel::DEBUG, $commandFailedLevel = LogLevel::ERROR)
     {
-        return ['class' => get_class($command)];
+        $this->commandReceivedLevel = $commandReceivedLevel;
+        $this->commandSucceededLevel = $commandSucceededLevel;
+        $this->commandFailedLevel = $commandFailedLevel;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function failureContext(array $currentContext, \Exception $e)
+    public function logCommandReceived(LoggerInterface $logger, $command)
     {
-        return $currentContext + ['exception' => $e];
+        $logger->log($this->commandReceivedLevel, 'Command received: ' . get_class($command), []);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function logCommandSucceeded(LoggerInterface $logger, $command, $returnValue)
+    {
+        $logger->log($this->commandSucceededLevel, 'Command succeeded: ' . get_class($command), []);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function logCommandFailed(LoggerInterface $logger, $command, Exception $e)
+    {
+        $logger->log(
+            $this->commandFailedLevel,
+            'Command failed: ' . get_class($command),
+            ['exception' => $e]
+        );
     }
 }

--- a/src/Formatter/ClassNameFormatter.php
+++ b/src/Formatter/ClassNameFormatter.php
@@ -48,6 +48,6 @@ class ClassNameFormatter implements Formatter
      */
     public function failureContext(array $currentContext, \Exception $e)
     {
-        return ['error' => ['class' => get_class($e), 'message' => $e->getMessage()]] + $currentContext;
+        return $currentContext + ['exception' => $e];
     }
 }

--- a/src/Formatter/ClassNameFormatter.php
+++ b/src/Formatter/ClassNameFormatter.php
@@ -30,8 +30,11 @@ class ClassNameFormatter implements Formatter
      * @param string $commandSucceededLevel
      * @param string $commandFailedLevel
      */
-    public function __construct($commandReceivedLevel = LogLevel::DEBUG, $commandSucceededLevel = LogLevel::DEBUG, $commandFailedLevel = LogLevel::ERROR)
-    {
+    public function __construct(
+        $commandReceivedLevel = LogLevel::DEBUG,
+        $commandSucceededLevel = LogLevel::DEBUG,
+        $commandFailedLevel = LogLevel::ERROR
+    ) {
         $this->commandReceivedLevel = $commandReceivedLevel;
         $this->commandSucceededLevel = $commandSucceededLevel;
         $this->commandFailedLevel = $commandFailedLevel;

--- a/src/Formatter/ClassPropertiesFormatter.php
+++ b/src/Formatter/ClassPropertiesFormatter.php
@@ -4,11 +4,13 @@ namespace League\Tactician\Logger\Formatter;
 use League\Tactician\Logger\PropertyNormalizer\PropertyNormalizer;
 use League\Tactician\Logger\PropertyNormalizer\SimplePropertyNormalizer;
 use Exception;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  * Formatter that includes the Command's name and properties for more detail
  */
-class ClassPropertiesFormatter extends ClassNameFormatter
+class ClassPropertiesFormatter implements Formatter
 {
     /**
      * @var PropertyNormalizer
@@ -16,18 +18,74 @@ class ClassPropertiesFormatter extends ClassNameFormatter
     private $normalizer;
 
     /**
-     * @param PropertyNormalizer $normalizer
+     * @var string
      */
-    public function __construct(PropertyNormalizer $normalizer = null)
-    {
+    private $commandReceivedLevel;
+
+    /**
+     * @var string
+     */
+    private $commandSucceededLevel;
+
+    /**
+     * @var string
+     */
+    private $commandFailedLevel;
+
+    /**
+     * @param PropertyNormalizer $normalizer
+     * @param string $commandReceivedLevel
+     * @param string $commandSucceededLevel
+     * @param string $commandFailedLevel
+     */
+    public function __construct(
+        PropertyNormalizer $normalizer = null,
+        $commandReceivedLevel = LogLevel::DEBUG,
+        $commandSucceededLevel = LogLevel::DEBUG,
+        $commandFailedLevel = LogLevel::ERROR
+    ) {
+
         $this->normalizer = $normalizer ?: new SimplePropertyNormalizer();
+        $this->commandReceivedLevel = $commandReceivedLevel;
+        $this->commandSucceededLevel = $commandSucceededLevel;
+        $this->commandFailedLevel = $commandFailedLevel;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function commandContext($command)
+    public function logCommandReceived(LoggerInterface $logger, $command)
     {
-        return $this->normalizer->normalize($command) + parent::commandContext($command);
+        $logger->log(
+            $this->commandReceivedLevel,
+            'Command received: ' . get_class($command),
+            ['command' => $this->normalizer->normalize($command)]
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function logCommandSucceeded(LoggerInterface $logger, $command, $returnValue)
+    {
+        $logger->log(
+            $this->commandSucceededLevel,
+            'Command succeeded: ' . get_class($command),
+            [
+                'command' => $this->normalizer->normalize($command)
+            ]
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function logCommandFailed(LoggerInterface $logger, $command, Exception $e)
+    {
+        $logger->log(
+            $this->commandFailedLevel,
+            'Command failed: ' . get_class($command),
+            ['exception' => $e]
+        );
     }
 }

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -12,6 +12,25 @@ use Exception;
  *
  * commandReceived() and commandHandled() receive only the command, however
  * commandFailed() also receives the exception that caused the failure.
+ *
+ * commandContext() and failureContext() create a key/value array that can be
+ * stored in your log's context. commandContext() is *only* added when a
+ * a commmand is handled and when a command is received, NOT when it fails.
+ *
+ * commandFailed(), on the other hand, is extra data you can choose to include
+ * when a command fails. It has access to the previous context, as well as the
+ * original exception. The output of commandFailed() is what's directly passed
+ * to the log, so if you'd like it to contain the same data as commandContext()
+ * you should merge the two before returning from commandFailed.
+ *
+ * If you'd prefer to have the messages blank or the contexts empty for a
+ * particular step, just return null or an empty array respectively.
+ *
+ * For an example of what this all looks like, take a look at the
+ * ClassNameFormatter example bundled with this package.
+ *
+ * For more information about log contexts:
+ * @see https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#13-context
  */
 interface Formatter
 {

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -2,66 +2,45 @@
 namespace League\Tactician\Logger\Formatter;
 
 use Exception;
+use Psr\Log\LoggerInterface;
 
 /**
  * Converts incoming Commands into log messages.
  *
- * Each method is invoked for a specific use case and can return either string
- * or null. Any string will be written to the logger, nulls will be ignored and
- * write nothing to the log.
- *
- * commandReceived() and commandHandled() receive only the command, however
- * commandFailed() also receives the exception that caused the failure.
- *
- * commandContext() and failureContext() create a key/value array that can be
- * stored in your log's context. commandContext() is *only* added when a
- * a commmand is handled and when a command is received, NOT when it fails.
- *
- * commandFailed(), on the other hand, is extra data you can choose to include
- * when a command fails. It has access to the previous context, as well as the
- * original exception. The output of commandFailed() is what's directly passed
- * to the log, so if you'd like it to contain the same data as commandContext()
- * you should merge the two before returning from commandFailed.
- *
- * If you'd prefer to have the messages blank or the contexts empty for a
- * particular step, just return null or an empty array respectively.
+ * Each method is written for a particular command path. A formatter class
+ * should take the given command, format it to a message and pass it to the
+ * given logger (with the desired log level).
  *
  * For an example of what this all looks like, take a look at the
  * ClassNameFormatter example bundled with this package.
  *
- * For more information about log contexts:
+ * A formatter may also use PSR-3 log contexts to pass extra info to the logger
+ * about the commands, return values and errors it receives. For more
+ * information about log contexts, see the PSR-3 specification.
  * @see https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#13-context
  */
 interface Formatter
 {
     /**
+     * @param LoggerInterface $logger
      * @param object $command
-     * @return string|null
+     * @return void
      */
-    public function commandReceived($command);
+    public function logCommandReceived(LoggerInterface $logger, $command);
 
     /**
+     * @param LoggerInterface $logger
      * @param object $command
-     * @return string|null
+     * @param mixed $returnValue
+     * @return void
      */
-    public function commandHandled($command);
+    public function logCommandSucceeded(LoggerInterface $logger, $command, $returnValue);
 
     /**
+     * @param LoggerInterface $logger
      * @param object $command
-     * @return string|null
+     * @param Exception $e
+     * @return void
      */
-    public function commandFailed($command);
-
-    /**
-     * @param object $command
-     * @return array
-     */
-    public function commandContext($command);
-
-    /**
-     * @param array $currentContext
-     * @param Exception $exception
-     * @return array
-     */
-    public function failureContext(array $currentContext, \Exception $exception);
+    public function logCommandFailed(LoggerInterface $logger, $command, Exception $e);
 }

--- a/src/LoggerMiddleware.php
+++ b/src/LoggerMiddleware.php
@@ -26,7 +26,8 @@ class LoggerMiddleware implements Middleware
      * @param Formatter $formatter
      * @param LoggerInterface $logger
      */
-    public function __construct(Formatter $formatter, LoggerInterface $logger) {
+    public function __construct(Formatter $formatter, LoggerInterface $logger)
+    {
         $this->formatter = $formatter;
         $this->logger = $logger;
     }

--- a/src/PropertyNormalizer/PropertyNormalizer.php
+++ b/src/PropertyNormalizer/PropertyNormalizer.php
@@ -2,13 +2,18 @@
 namespace League\Tactician\Logger\PropertyNormalizer;
 
 /**
- * Normalize an object's property values into a format fit for a log message.
+ * Normalize value into scalars, usually to put them in a log message's context
+ *
+ * If given an object, return an array of properties. If given scalars, just
+ * return them directly.
+ *
+ * Implementations should work on any value, not just commands or exceptions.
  */
 interface PropertyNormalizer
 {
     /**
-     * @param object $command
+     * @param mixed $value
      * @return string
      */
-    public function normalize($command);
+    public function normalize($value);
 }

--- a/src/PropertyNormalizer/SimplePropertyNormalizer.php
+++ b/src/PropertyNormalizer/SimplePropertyNormalizer.php
@@ -6,6 +6,8 @@ use ReflectionClass;
 /**
  * Quick'n'dirty property normalizer that logs the first level properties
  *
+ * Does not recurse into sub-objects or arrays.
+ *
  * This is done in an extremely inefficient manner, so please never use this in
  * a production context, only for local debugging.
  */
@@ -43,8 +45,6 @@ class SimplePropertyNormalizer implements PropertyNormalizer
                 return '*array*';
             case 'resource':
                 return 'resource(' . get_resource_type($value) . ')';
-            case 'NULL':
-                return '*null*';
             default:
                 return $value;
         }

--- a/tests/Formatter/ClassNameFormatterTest.php
+++ b/tests/Formatter/ClassNameFormatterTest.php
@@ -54,11 +54,8 @@ class ClassNameFormatterTest extends \PHPUnit_Framework_TestCase
         $exception = new UserAlreadyExistsException("foo bar baz");
         $this->assertEquals(
             [
-                'error' => [
-                    'class' => UserAlreadyExistsException::class,
-                    'message' => 'foo bar baz',
-                ],
-                'current' => 'context'
+                'current' => 'context',
+                'exception' => new UserAlreadyExistsException("foo bar baz")
             ],
             $this->formatter->failureContext(['current' => 'context'], $exception)
         );

--- a/tests/Formatter/ClassNameFormatterTest.php
+++ b/tests/Formatter/ClassNameFormatterTest.php
@@ -4,6 +4,9 @@ namespace League\Tactician\Logger\Tests\Formatter;
 use League\Tactician\Logger\Formatter\ClassNameFormatter;
 use League\Tactician\Logger\Tests\Fixtures\RegisterUserCommand;
 use League\Tactician\Logger\Tests\Fixtures\UserAlreadyExistsException;
+use Psr\Log\LoggerInterface;
+use Mockery;
+use Psr\Log\LogLevel;
 
 class ClassNameFormatterTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,52 +15,63 @@ class ClassNameFormatterTest extends \PHPUnit_Framework_TestCase
      */
     protected $formatter;
 
+    /**
+     * @var LoggerInterface|Mockery\MockInterface
+     */
+    protected $logger;
+
     protected function setUp()
     {
         $this->formatter = new ClassNameFormatter();
+        $this->logger = Mockery::mock(LoggerInterface::class);
     }
 
-    public function testCommandSuccessCreatesExpectedMessage()
+    public function testBasicSuccessMessageIsLogged()
     {
-        $this->assertEquals(
+        $this->logger->shouldReceive('log')->with(
+            LogLevel::DEBUG,
             'Command succeeded: ' . RegisterUserCommand::class,
-            $this->formatter->commandHandled(new RegisterUserCommand())
+            []
         );
+
+        $this->formatter->logCommandSucceeded($this->logger, new RegisterUserCommand(), null);
     }
 
     public function testCommandReceivedCreatesExpectedMessage()
     {
-        $this->assertEquals(
+        $this->logger->shouldReceive('log')->with(
+            LogLevel::DEBUG,
             'Command received: ' . RegisterUserCommand::class,
-            $this->formatter->commandReceived(new RegisterUserCommand())
+            []
         );
+
+        $this->formatter->logCommandReceived($this->logger, new RegisterUserCommand());
     }
 
     public function testCommandFailedCreatesExpectedMessage()
     {
-        $this->assertEquals(
+        $exception = new UserAlreadyExistsException();
+
+        $this->logger->shouldReceive('log')->with(
+            LogLevel::ERROR,
             'Command failed: ' . RegisterUserCommand::class,
-            $this->formatter->commandFailed(new RegisterUserCommand())
+            ['exception' => $exception]
         );
+
+        $this->formatter->logCommandFailed($this->logger, new RegisterUserCommand(), $exception);
     }
 
-    public function testCommandContextCreatesExpectedContext()
+    public function testCustomLogLevels()
     {
-        $this->assertEquals(
-            ['class' => RegisterUserCommand::class],
-            $this->formatter->commandContext(new RegisterUserCommand())
-        );
-    }
+        $formatter = new ClassNameFormatter(LogLevel::WARNING, LogLevel::NOTICE, LogLevel::EMERGENCY);
 
-    public function testCompleteContextOnFailureWithExceptionInfo()
-    {
-        $exception = new UserAlreadyExistsException("foo bar baz");
-        $this->assertEquals(
-            [
-                'current' => 'context',
-                'exception' => new UserAlreadyExistsException("foo bar baz")
-            ],
-            $this->formatter->failureContext(['current' => 'context'], $exception)
-        );
+        $this->logger->shouldReceive('log')->with(LogLevel::WARNING, Mockery::any(), Mockery::any())->once();
+        $formatter->logCommandReceived($this->logger, new RegisterUserCommand());
+
+        $this->logger->shouldReceive('log')->with(LogLevel::NOTICE, Mockery::any(), Mockery::any())->once();
+        $formatter->logCommandSucceeded($this->logger, new RegisterUserCommand(), null);
+
+        $this->logger->shouldReceive('log')->with(LogLevel::EMERGENCY, Mockery::any(), Mockery::any())->once();
+        $formatter->logCommandFailed($this->logger, new RegisterUserCommand(), new UserAlreadyExistsException());
     }
 }

--- a/tests/Formatter/ClassPropertiesFormatterTest.php
+++ b/tests/Formatter/ClassPropertiesFormatterTest.php
@@ -75,7 +75,12 @@ class ClassPropertiesFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function testCustomLogLevels()
     {
-        $formatter = new ClassPropertiesFormatter($this->normalizer, LogLevel::WARNING, LogLevel::NOTICE, LogLevel::EMERGENCY);
+        $formatter = new ClassPropertiesFormatter(
+            $this->normalizer,
+            LogLevel::WARNING,
+            LogLevel::NOTICE,
+            LogLevel::EMERGENCY
+        );
 
         $this->logger->shouldReceive('log')->with(LogLevel::WARNING, Mockery::any(), Mockery::any())->once();
         $formatter->logCommandReceived($this->logger, new RegisterUserCommand());

--- a/tests/Formatter/ClassPropertiesFormatterTest.php
+++ b/tests/Formatter/ClassPropertiesFormatterTest.php
@@ -7,27 +7,83 @@ use League\Tactician\Logger\Tests\Fixtures\RegisterUserCommand;
 use League\Tactician\Logger\Tests\Fixtures\UserAlreadyExistsException;
 use Mockery;
 use Mockery\MockInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
-class ClassPropertiesFormatterTest extends ClassNameFormatterTest
+class ClassPropertiesFormatterTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var PropertyNormalizer|MockInterface
      */
     private $normalizer;
 
+    /**
+     * @var ClassPropertiesFormatter
+     */
+    protected $formatter;
+
+    /**
+     * @var LoggerInterface|Mockery\MockInterface
+     */
+    protected $logger;
+
+
     protected function setUp()
     {
         $this->normalizer = Mockery::mock(PropertyNormalizer::class);
-        $this->normalizer->shouldReceive('normalize')->andReturn(['!!!']);
+        $this->normalizer->shouldReceive('normalize')->andReturn(['test' => 'data']);
+
+        $this->logger = Mockery::mock(LoggerInterface::class);
 
         $this->formatter = new ClassPropertiesFormatter($this->normalizer);
     }
 
-    public function testCommandContextCreatesExpectedContext()
+    public function testBasicSuccessMessageIsLogged()
     {
-        $this->assertEquals(
-            ['!!!', 'class' => RegisterUserCommand::class],
-            $this->formatter->commandContext(new RegisterUserCommand())
+        $this->logger->shouldReceive('log')->with(
+            LogLevel::DEBUG,
+            'Command succeeded: ' . RegisterUserCommand::class,
+            ['command' => ['test' => 'data']]
         );
+
+        $this->formatter->logCommandSucceeded($this->logger, new RegisterUserCommand(), null);
+    }
+
+    public function testCommandReceivedCreatesExpectedMessage()
+    {
+        $this->logger->shouldReceive('log')->with(
+            LogLevel::DEBUG,
+            'Command received: ' . RegisterUserCommand::class,
+            ['command' => ['test' => 'data']]
+        );
+
+        $this->formatter->logCommandReceived($this->logger, new RegisterUserCommand());
+    }
+
+    public function testCommandFailedCreatesExpectedMessage()
+    {
+        $exception = new UserAlreadyExistsException();
+
+        $this->logger->shouldReceive('log')->with(
+            LogLevel::ERROR,
+            'Command failed: ' . RegisterUserCommand::class,
+            ['exception' => $exception]
+        );
+
+        $this->formatter->logCommandFailed($this->logger, new RegisterUserCommand(), $exception);
+    }
+
+    public function testCustomLogLevels()
+    {
+        $formatter = new ClassPropertiesFormatter($this->normalizer, LogLevel::WARNING, LogLevel::NOTICE, LogLevel::EMERGENCY);
+
+        $this->logger->shouldReceive('log')->with(LogLevel::WARNING, Mockery::any(), Mockery::any())->once();
+        $formatter->logCommandReceived($this->logger, new RegisterUserCommand());
+
+        $this->logger->shouldReceive('log')->with(LogLevel::NOTICE, Mockery::any(), Mockery::any())->once();
+        $formatter->logCommandSucceeded($this->logger, new RegisterUserCommand(), null);
+
+        $this->logger->shouldReceive('log')->with(LogLevel::EMERGENCY, Mockery::any(), Mockery::any())->once();
+        $formatter->logCommandFailed($this->logger, new RegisterUserCommand(), new UserAlreadyExistsException());
     }
 }

--- a/tests/LoggerMiddlewareTest.php
+++ b/tests/LoggerMiddlewareTest.php
@@ -59,7 +59,12 @@ class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->formatter->shouldReceive('logCommandReceived')->with($this->logger, $command)->once();
         $this->formatter->shouldReceive('logCommandSucceeded')->with($this->logger, $command, null)->once();
 
-        $this->middleware->execute($command, function () {});
+        $this->middleware->execute(
+            $command,
+            function () {
+                // no-op
+            }
+        );
     }
 
     /**

--- a/tests/LoggerMiddlewareTest.php
+++ b/tests/LoggerMiddlewareTest.php
@@ -5,22 +5,22 @@ use League\Tactician\Logger\Formatter\Formatter;
 use League\Tactician\Logger\LoggerMiddleware;
 use League\Tactician\Logger\Tests\Fixtures\RegisterUserCommand;
 use League\Tactician\Logger\Tests\Fixtures\UserAlreadyExistsException;
-use Psr\Log\LoggerInterface;
 use Mockery;
 use Mockery\MockInterface;
+use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
 class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @var LoggerMiddleware
      */
     private $middleware;
-
-    /**
-     * @var LoggerInterface|MockInterface
-     */
-    private $logger;
 
     /**
      * @var Formatter|MockInterface
@@ -35,50 +35,43 @@ class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->logger = Mockery::mock(LoggerInterface::class);
-
         $this->formatter = Mockery::mock(Formatter::class);
 
-        $this->middleware = new LoggerMiddleware(
-            $this->formatter,
-            $this->logger
-        );
-
-        $this->mockNext = function () {
-        };
+        $this->middleware = new LoggerMiddleware($this->formatter, $this->logger);
     }
 
-    public function testSuccessMessagesAreLoggedExactly()
+    public function testSuccessfulEventsLogWithCommandAndReturnValue()
     {
         $command = new RegisterUserCommand();
 
-        $this->formatter->shouldReceive('commandReceived')->with($command)->once()->andReturn('foo bar');
-        $this->formatter->shouldReceive('commandHandled')->with($command)->once()->andReturn('baz blat');
-        $this->formatter->shouldReceive('commandContext')->with($command)->once()->andReturn(['foo' => 'bar']);
+        $this->formatter->shouldReceive('logCommandReceived')->with($this->logger, $command)->once();
+        $this->formatter->shouldReceive('logCommandSucceeded')->with($this->logger, $command, 'blat bart')->once();
 
-        $this->logger->shouldReceive('log')->with(LogLevel::DEBUG, 'foo bar', ['foo' => 'bar'])->once();
-        $this->logger->shouldReceive('log')->with(LogLevel::DEBUG, 'baz blat', ['foo' => 'bar'])->once();
+        $this->middleware->execute($command, function () {
+            return 'blat bart';
+        });
+    }
 
-        $this->middleware->execute($command, $this->mockNext);
+    public function testEmptyReturnValuesIsPassedAsNull()
+    {
+        $command = new RegisterUserCommand();
+
+        $this->formatter->shouldReceive('logCommandReceived')->with($this->logger, $command)->once();
+        $this->formatter->shouldReceive('logCommandSucceeded')->with($this->logger, $command, null)->once();
+
+        $this->middleware->execute($command, function () {});
     }
 
     /**
      * @expectedException \League\Tactician\Logger\Tests\Fixtures\UserAlreadyExistsException
      */
-    public function testFailureMessagesAreLogged()
+    public function testFailuresMessagesAreLoggedWithException()
     {
         $command = new RegisterUserCommand();
         $exception = new UserAlreadyExistsException();
 
-        $this->formatter->shouldReceive('commandReceived')->with($command)->once()->andReturn('foo bar');
-        $this->formatter->shouldReceive('commandFailed')->with($command)->once()->andReturn('baz blat');
-        $this->formatter->shouldReceive('commandContext')->with($command)->once()->andReturn(['foo' => 'bar']);
-        $this->formatter
-            ->shouldReceive('failureContext')->with(['foo' => 'bar'], $exception)->once()
-            ->andReturn(['exception' => 'bar'])
-        ;
-
-        $this->logger->shouldReceive('log')->with(LogLevel::DEBUG, 'foo bar', ['foo' => 'bar'])->once();
-        $this->logger->shouldReceive('log')->with(LogLevel::ERROR, 'baz blat', ['exception' => 'bar'])->once();
+        $this->formatter->shouldReceive('logCommandReceived')->with($this->logger, $command)->once();
+        $this->formatter->shouldReceive('logCommandFailed')->with($this->logger, $command, $exception)->once();
 
         $this->middleware->execute(
             $command,
@@ -92,10 +85,8 @@ class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
     {
         $this->logger->shouldIgnoreMissing();
         $this->formatter->shouldIgnoreMissing();
-        $this->formatter->shouldReceive('commandContext')->andReturn([]);
 
         $sentCommand = new RegisterUserCommand();
-
         $receivedSameCommand = false;
         $next = function ($receivedCommand) use (&$receivedSameCommand, $sentCommand) {
             $receivedSameCommand = ($receivedCommand === $sentCommand);
@@ -104,59 +95,5 @@ class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->middleware->execute($sentCommand, $next);
 
         $this->assertTrue($receivedSameCommand);
-    }
-
-    public function testNullMessagesAreNotLoggedForThatSpecificMessage()
-    {
-        $this->formatter->shouldReceive('commandReceived')->andReturnNull();
-        $this->formatter->shouldReceive('commandHandled')->andReturn('foo bar');
-        $this->formatter->shouldReceive('commandContext')->andReturn([]);
-
-        $this->logger->shouldReceive('log')->with(LogLevel::DEBUG, 'foo bar', []);
-
-        $this->middleware->execute(new RegisterUserCommand(), $this->mockNext);
-    }
-
-    public function testCustomizableLogLevelsWork()
-    {
-        $middleware = new LoggerMiddleware($this->formatter, $this->logger, LogLevel::ALERT, LogLevel::CRITICAL);
-
-        $this->formatter->shouldReceive('commandReceived')->andReturn('received');
-        $this->formatter->shouldReceive('commandHandled')->andReturn('completed');
-        $this->formatter->shouldReceive('commandContext')->andReturn([]);
-
-        $this->logger->shouldReceive('log')->with(LogLevel::ALERT, 'received', []);
-        $this->logger->shouldReceive('log')->with(LogLevel::CRITICAL, 'completed', []);
-
-        $middleware->execute(new RegisterUserCommand(), $this->mockNext);
-    }
-
-    /**
-     * @expectedException \League\Tactician\Logger\Tests\Fixtures\UserAlreadyExistsException
-     */
-    public function testErrorLogLevelCanBeCustomized()
-    {
-        $middleware = new LoggerMiddleware(
-            $this->formatter,
-            $this->logger,
-            LogLevel::DEBUG,
-            LogLevel::DEBUG,
-            LogLevel::CRITICAL
-        );
-
-        $this->formatter->shouldReceive('commandReceived')->andReturn('received');
-        $this->formatter->shouldReceive('commandFailed')->andReturn('failed');
-        $this->formatter->shouldReceive('commandContext')->andReturn([]);
-        $this->formatter->shouldReceive('failureContext')->andReturn([]);
-
-        $this->logger->shouldReceive('log')->with(LogLevel::DEBUG, 'received', []);
-        $this->logger->shouldReceive('log')->with(LogLevel::CRITICAL, 'failed', []);
-
-        $middleware->execute(
-            new RegisterUserCommand(),
-            function () {
-                throw new UserAlreadyExistsException();
-            }
-        );
     }
 }

--- a/tests/PropertyNormalizer/SimplePropertySerializerTest.php
+++ b/tests/PropertyNormalizer/SimplePropertySerializerTest.php
@@ -20,7 +20,7 @@ class SimplePropertyNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             ["name" => "Alice", "emailAddress" => "alice@example.org", "age" => 30.5, "createdAt" => "object(DateTime)",
-            "file" => "resource(stream)", "empty" => "*null*", "options" => "*array*"],
+            "file" => "resource(stream)", "empty" => null, "options" => "*array*"],
             $this->normalizer->normalize(new RegisterUserCommand())
         );
     }


### PR DESCRIPTION
Before tagging a new release, I added a few docs, please let me know if you have any improvements, @tyx @boekkooi.

Also, I made one other change here that I'd like your feedback on: when looking at PSR-3, I noticed there's a clause in the context documentation about [a standard "exception" key](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#13-context) to hold original exception objects in, so that other storage utils can inspect the original error and collect the stack trace if they wanted.

That makes a lot of sense to me, but I was worried about clogging up file logs, so I hacked together a few tests. In general, Monolog outputs this format:

```
[2016-05-22 10:05:17] name.ERROR: Bar {"key":"value","exception":"[object] (LogicException(code: 0): battery empty at /home/rtuck/code/tactician/logger-test/test.php:18)"} []
```

This is a little more verbose but it doesn't include the entire stacktrace (unless you enable that in monolog). I'm not sure how other libraries handle Exception objects but I imagine they follow the spec reasonably well here, so I'd propose making this change before we tag an 0.10.

Let me know if you have any objections :)