### PR TITLE
Allow php 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: ['ubuntu-latest']
-                php-versions: ['5.5', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+                php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         runs-on: ${{ matrix.operating-system }}
         steps:
             -   name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: ['ubuntu-latest']
-                php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+                php-versions: ['7.3', '7.4', '8.0', '8.1']
         runs-on: ${{ matrix.operating-system }}
         steps:
             -   name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
         }
     ],
     "require": {
-        "php" : ">=5.5.0",
-        "psr/log": "~1.0",
-        "league/tactician": "^1.0"
+        "php" : ">=7.1",
+        "psr/log": ">=1.0",
+        "league/tactician": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit" : "4.*",
-        "mockery/mockery": "^0.9",
-        "squizlabs/php_codesniffer": "~2.3"
+        "phpunit/phpunit" : "^7.5|^9.3",
+        "mockery/mockery": "^1.3",
+        "squizlabs/php_codesniffer": "^3.5.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php" : ">=7.1",
-        "psr/log": ">=1.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "league/tactician": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         }
     ],
     "require": {
-        "php" : ">=7.1",
+        "php" : ">=7.3",
         "psr/log": "^1.0|^2.0|^3.0",
         "league/tactician": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^7.5|^9.3",
+        "phpunit/phpunit" : "^9.3",
         "mockery/mockery": "^1.3",
         "squizlabs/php_codesniffer": "^3.5.8"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,32 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+         verbose="true">
+    <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage" />
+            <text outputFile="build/coverage.txt" />
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+
     <testsuites>
         <testsuite name="League Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <listeners>
-        <listener class='Mockery\Adapter\Phpunit\TestListener' />
-    </listeners>
+
     <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <junit outputFile="build/report.junit.xml"/>
     </logging>
+
 </phpunit>

--- a/tests/Formatter/ClassNameFormatterTest.php
+++ b/tests/Formatter/ClassNameFormatterTest.php
@@ -4,12 +4,15 @@ namespace League\Tactician\Logger\Tests\Formatter;
 use League\Tactician\Logger\Formatter\ClassNameFormatter;
 use League\Tactician\Logger\Tests\Fixtures\RegisterUserCommand;
 use League\Tactician\Logger\Tests\Fixtures\UserAlreadyExistsException;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Mockery;
 use Psr\Log\LogLevel;
 
-class ClassNameFormatterTest extends \PHPUnit_Framework_TestCase
+class ClassNameFormatterTest extends TestCase
 {
+    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
     /**
      * @var ClassNameFormatter
      */
@@ -20,10 +23,15 @@ class ClassNameFormatterTest extends \PHPUnit_Framework_TestCase
      */
     protected $logger;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->formatter = new ClassNameFormatter();
         $this->logger = Mockery::mock(LoggerInterface::class);
+    }
+
+    public function tearDown(): void
+    {
+        Mockery::close();
     }
 
     public function testBasicSuccessMessageIsLogged()

--- a/tests/Formatter/ClassNameFormatterTest.php
+++ b/tests/Formatter/ClassNameFormatterTest.php
@@ -4,6 +4,7 @@ namespace League\Tactician\Logger\Tests\Formatter;
 use League\Tactician\Logger\Formatter\ClassNameFormatter;
 use League\Tactician\Logger\Tests\Fixtures\RegisterUserCommand;
 use League\Tactician\Logger\Tests\Fixtures\UserAlreadyExistsException;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Mockery;
@@ -11,7 +12,7 @@ use Psr\Log\LogLevel;
 
 class ClassNameFormatterTest extends TestCase
 {
-    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+    use MockeryPHPUnitIntegration;
 
     /**
      * @var ClassNameFormatter

--- a/tests/Formatter/ClassPropertiesFormatterTest.php
+++ b/tests/Formatter/ClassPropertiesFormatterTest.php
@@ -6,6 +6,7 @@ use League\Tactician\Logger\PropertyNormalizer\PropertyNormalizer;
 use League\Tactician\Logger\Tests\Fixtures\RegisterUserCommand;
 use League\Tactician\Logger\Tests\Fixtures\UserAlreadyExistsException;
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -13,7 +14,7 @@ use Psr\Log\LogLevel;
 
 class ClassPropertiesFormatterTest extends TestCase
 {
-    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+    use MockeryPHPUnitIntegration;
 
     /**
      * @var PropertyNormalizer|MockInterface

--- a/tests/Formatter/ClassPropertiesFormatterTest.php
+++ b/tests/Formatter/ClassPropertiesFormatterTest.php
@@ -7,11 +7,14 @@ use League\Tactician\Logger\Tests\Fixtures\RegisterUserCommand;
 use League\Tactician\Logger\Tests\Fixtures\UserAlreadyExistsException;
 use Mockery;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
-class ClassPropertiesFormatterTest extends \PHPUnit_Framework_TestCase
+class ClassPropertiesFormatterTest extends TestCase
 {
+    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
     /**
      * @var PropertyNormalizer|MockInterface
      */
@@ -28,7 +31,7 @@ class ClassPropertiesFormatterTest extends \PHPUnit_Framework_TestCase
     protected $logger;
 
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->normalizer = Mockery::mock(PropertyNormalizer::class);
         $this->normalizer->shouldReceive('normalize')->andReturn(['test' => 'data']);

--- a/tests/LoggerMiddlewareTest.php
+++ b/tests/LoggerMiddlewareTest.php
@@ -6,13 +6,14 @@ use League\Tactician\Logger\LoggerMiddleware;
 use League\Tactician\Logger\Tests\Fixtures\RegisterUserCommand;
 use League\Tactician\Logger\Tests\Fixtures\UserAlreadyExistsException;
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 class LoggerMiddlewareTest extends TestCase
 {
-    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+    use MockeryPHPUnitIntegration;
 
     /**
      * @var LoggerInterface

--- a/tests/PropertyNormalizer/SimplePropertySerializerTest.php
+++ b/tests/PropertyNormalizer/SimplePropertySerializerTest.php
@@ -3,15 +3,16 @@ namespace League\Tactician\Logger\Tests\PropertyNormalizer;
 
 use League\Tactician\Logger\PropertyNormalizer\SimplePropertyNormalizer;
 use League\Tactician\Logger\Tests\Fixtures\RegisterUserCommand;
+use PHPUnit\Framework\TestCase;
 
-class SimplePropertyNormalizerTest extends \PHPUnit_Framework_TestCase
+class SimplePropertyNormalizerTest extends TestCase
 {
     /**
      * @var SimplePropertyNormalizer
      */
     private $normalizer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->normalizer = new SimplePropertyNormalizer();
     }


### PR DESCRIPTION
In order to make the CI pipeline succeed, I had to set the minimum php requirement to php 7.3. Mainly because of the changed structure of phpunit.xml. It also makes sense that a new release stops support for abandoned php versions. For those versions the old tactician 1 releases can be used.

For the rest I tried to match the requirements of league/tactician 1.1.0