### PR TITLE
Handle implicitly nullable parameter declaration (php 8.4 depreciation)

### DIFF
--- a/src/Formatter/ClassPropertiesFormatter.php
+++ b/src/Formatter/ClassPropertiesFormatter.php
@@ -39,7 +39,7 @@ class ClassPropertiesFormatter implements Formatter
      * @param string $commandFailedLevel
      */
     public function __construct(
-        PropertyNormalizer $normalizer = null,
+        ?PropertyNormalizer $normalizer = null,
         $commandReceivedLevel = LogLevel::DEBUG,
         $commandSucceededLevel = LogLevel::DEBUG,
         $commandFailedLevel = LogLevel::ERROR


### PR DESCRIPTION
Why I did this change: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated