### PR TITLE
Remove "setAccessible()" method call as it has no effect since PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php" : "^8.2",
         "psr/log": "^2.0 || ^3.0",
-        "league/tactician": "dev-master"
+        "league/tactician": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^11.5",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php" : "^8.2",
         "psr/log": "^2.0 || ^3.0",
-        "league/tactician": "^1.6"
+        "league/tactician": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit" : "^11.5",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php" : "^8.2",
         "psr/log": "^2.0 || ^3.0",
-        "league/tactician": "dev-master"
+        "league/tactician": "^1.6"
     },
     "require-dev": {
         "phpunit/phpunit" : "^11.5",

--- a/src/PropertyNormalizer/SimplePropertyNormalizer.php
+++ b/src/PropertyNormalizer/SimplePropertyNormalizer.php
@@ -26,7 +26,6 @@ class SimplePropertyNormalizer implements PropertyNormalizer
 
         $properties = [];
         foreach ($reflectionClass->getProperties() as $property) {
-            $property->setAccessible(true);
             $properties[$property->getName()] = $this->formatValue($property->getValue($command));
         }
 


### PR DESCRIPTION
As of PHP 8.5, the deprecation of "setAccessible" method has been made. Therefore, eg. running tests creates a deprecation notice:

X tests triggered 1 PHP deprecation:

1) /var/www/html/vendor/league/tactician-logger/src/PropertyNormalizer/SimplePropertyNormalizer.php:26
Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1