### PR TITLE
Remove deprecated method call

### DIFF
--- a/src/PropertyNormalizer/SimplePropertyNormalizer.php
+++ b/src/PropertyNormalizer/SimplePropertyNormalizer.php
@@ -26,7 +26,6 @@ class SimplePropertyNormalizer implements PropertyNormalizer
 
         $properties = [];
         foreach ($reflectionClass->getProperties() as $property) {
-            $property->setAccessible(true);
             $properties[$property->getName()] = $this->formatValue($property->getValue($command));
         }
 


### PR DESCRIPTION
Fixes

```
1 test triggered 1 PHP deprecation:

1) tactician-logger/src/PropertyNormalizer/SimplePropertyNormalizer.php:29
Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1

Triggered by:

* League\Tactician\Logger\Tests\PropertyNormalizer\SimplePropertyNormalizerTest::testCommandPropertiesCanBeDumpedToString (7 times)
```